### PR TITLE
Potential fix for build-time compilation error

### DIFF
--- a/Runtime/Values/BaseValue.cs
+++ b/Runtime/Values/BaseValue.cs
@@ -60,7 +60,7 @@
 #if UNITY_EDITOR
             return SerializationHelper.CreateCopy(originalValue);
 #else
-            return value;
+            return originalValue;
 #endif
         }
     }


### PR DESCRIPTION
This change is intended to address a compilation error that crops up in BaseValue.cs when building a project.  Looks like 'return value' should potentially be 'return originalValue' instead?